### PR TITLE
Improvements1

### DIFF
--- a/pymathics/matplotlib/__init__.py
+++ b/pymathics/matplotlib/__init__.py
@@ -5,10 +5,10 @@ PyMathics MatPlotLib module.
 
 import os
 from pymathics.matplotlib.version import __version__
-from pymathics.matplotlib.__main__ import MPLGraphicsBox
+from pymathics.matplotlib.__main__ import MPLGraphicsBox, MPLGraphicsExport
 #MPLExportGraphics, MPLShow, MPLExportGraphicsToString # noqa
 
-__all__ = ("__version__", "MPLGraphicsBox", "pymathics_version_data")
+__all__ = ("__version__", "MPLGraphicsBox", "pymathics_version_data", "MPLGraphicsExport")
 #__all__ = ("__version__", "MPLExportGraphicsToString", "MPLExportGraphics", "MPLShow", "pymathics_version_data")
 
 # To be recognized as an external mathics module, the following variable

--- a/pymathics/matplotlib/__init__.py
+++ b/pymathics/matplotlib/__init__.py
@@ -5,9 +5,9 @@ PyMathics MatPlotLib module.
 
 import os
 from pymathics.matplotlib.version import __version__
-from pymathics.matplotlib.__main__ import ToMatplotlib, MPlot # noqa
+from pymathics.matplotlib.__main__ import MLPExportGraphics, MPLShow # noqa
 
-__all__ = ("__version__", "ToMatplotlib", "MPlot", "pymathics_version_data")
+__all__ = ("__version__", "MLPExportGraphics", "MPLShow", "pymathics_version_data")
 
 # To be recognized as an external mathics module, the following variable
 # is required:

--- a/pymathics/matplotlib/__init__.py
+++ b/pymathics/matplotlib/__init__.py
@@ -5,9 +5,11 @@ PyMathics MatPlotLib module.
 
 import os
 from pymathics.matplotlib.version import __version__
-from pymathics.matplotlib.__main__ import MPLExportGraphics, MPLShow, MPLExportGraphicsToString # noqa
+from pymathics.matplotlib.__main__ import MPLGraphicsBox
+#MPLExportGraphics, MPLShow, MPLExportGraphicsToString # noqa
 
-__all__ = ("__version__", "MPLExportGraphicsToString", "MPLExportGraphics", "MPLShow", "pymathics_version_data")
+__all__ = ("__version__", "MPLGraphicsBox", "pymathics_version_data")
+#__all__ = ("__version__", "MPLExportGraphicsToString", "MPLExportGraphics", "MPLShow", "pymathics_version_data")
 
 # To be recognized as an external mathics module, the following variable
 # is required:
@@ -17,3 +19,5 @@ pymathics_version_data = {
     "version": __version__,
     "requires": [],
 }
+
+

--- a/pymathics/matplotlib/__init__.py
+++ b/pymathics/matplotlib/__init__.py
@@ -5,9 +5,9 @@ PyMathics MatPlotLib module.
 
 import os
 from pymathics.matplotlib.version import __version__
-from pymathics.matplotlib.__main__ import MLPExportGraphics, MPLShow # noqa
+from pymathics.matplotlib.__main__ import MPLExportGraphics, MPLShow # noqa
 
-__all__ = ("__version__", "MLPExportGraphics", "MPLShow", "pymathics_version_data")
+__all__ = ("__version__", "MPLExportGraphics", "MPLShow", "pymathics_version_data")
 
 # To be recognized as an external mathics module, the following variable
 # is required:

--- a/pymathics/matplotlib/__init__.py
+++ b/pymathics/matplotlib/__init__.py
@@ -5,9 +5,9 @@ PyMathics MatPlotLib module.
 
 import os
 from pymathics.matplotlib.version import __version__
-from pymathics.matplotlib.__main__ import MPLExportGraphics, MPLShow # noqa
+from pymathics.matplotlib.__main__ import MPLExportGraphics, MPLShow, MPLExportGraphicsToString # noqa
 
-__all__ = ("__version__", "MPLExportGraphics", "MPLShow", "pymathics_version_data")
+__all__ = ("__version__", "MPLExportGraphicsToString", "MPLExportGraphics", "MPLShow", "pymathics_version_data")
 
 # To be recognized as an external mathics module, the following variable
 # is required:

--- a/pymathics/matplotlib/__main__.py
+++ b/pymathics/matplotlib/__main__.py
@@ -6,7 +6,7 @@ from mathics.core.rules import Rule
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
 from matplotlib.collections import PatchCollection
-
+from mathics.builtin.colors import hsb_to_rgb
 
 class WL2MLP:
     def __init__(self, expr, evaluation):
@@ -75,6 +75,12 @@ class WL2MLP:
             rgbcolor = [ c.to_python() for c in rgbcolor]
             print("rgbcolor=",rgbcolor)
             brush["color"] = rgbcolor
+        elif head_name == "System`Hue":
+            huecolor = [0,1.,1.,1.]
+            for i, leaf in enumerate(graphics_expr.leaves):
+                huecolor[i] = float(leaf.to_python())
+            rgbcolor = hsb_to_rgb(*huecolor)
+            brush["color"] = set(rgbcolor[:3])
         elif head_name == "System`Line":
             self.matplotlib = self.add_line(graphics_expr, evaluation)
         elif head_name == "System`Text":

--- a/pymathics/matplotlib/__main__.py
+++ b/pymathics/matplotlib/__main__.py
@@ -305,10 +305,17 @@ class MPLExportGraphics(Builtin):
         wl2mpl = WL2MLP(expr, evaluation, drawsymbols=True)
         context = wl2mpl.context
         try:
+            if type(format) is String:
+                format = format.get_string_value()
+            elif len(format.leaves)>0:
+                format=format.leaves[0].get_string_value()
+            else:
+                format = None
+            
             if format:
                 wl2mpl.export(filename.get_string_value(),
                               evaluation,
-                              format=format.get_string_value())
+                              format=format)
             else:
                 wl2mpl.export(filename.get_string_value(),
                               evaluation
@@ -317,7 +324,51 @@ class MPLExportGraphics(Builtin):
             evaluation.message("System`ConvertersDump","error",expr, filename)
             raise
         return filename
-    
+
+
+class MPLExportGraphicsToString(Builtin):
+    """
+    <dl>
+      <dt>'System`ConvertersDump`MPLExportGraphicsToString'[$graphics$]
+      <dd>Export  $graphics$ to a file $filename$
+      <dt>'System`ConvertersDump`MPLExportGraphics'[$filename$, $graphics$, $format$]
+      <dd>Force to use $format$.
+    </dl>
+    """
+    messages = {
+        "errexp": "`1` could not be saved in `2`",
+    }
+    options = GRAPHICS_OPTIONS
+
+    def apply(self, expr, format,  evaluation, options):
+        "MPLExportGraphicsToString[expr_, format___String,  OptionsPattern[MPLExportGraphicsToString]]"
+        from io import StringIO, BytesIO
+        out =  BytesIO()
+        wl2mpl = WL2MLP(expr, evaluation, drawsymbols=True)
+        context = wl2mpl.context
+        try:
+            if type(format) is String:
+                format = format.get_string_value()
+            elif len(format.leaves)>0:
+                format=format.leaves[0].get_string_value()
+            else:
+                format = None
+            if format:
+                print("format=", format)
+                wl2mpl.export(out,
+                              evaluation,
+                              format=format)
+            else:
+                print("should be svg")
+                wl2mpl.export(out,
+                              evaluation, format="SVG"
+                              )
+        except:
+            evaluation.message("System`ConvertersDump","error",expr)
+            raise
+        return String(out.getvalue().decode('utf8'))
+
+
 class MPLShow(Builtin):
     """
     <dl>

--- a/pymathics/matplotlib/__main__.py
+++ b/pymathics/matplotlib/__main__.py
@@ -1,13 +1,15 @@
 # -*- coding: utf-8 -*-
 import matplotlib.lines as lines
 from mathics.builtin.base import Builtin, String
-from mathics.core.expression import Expression, Symbol, from_python, strip_context
+from mathics.core.expression import Expression, Symbol, from_python
 from mathics.core.rules import Rule
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
 from matplotlib.collections import PatchCollection
 from mathics.builtin.colors import hsb_to_rgb
 from mathics.builtin.graphics import _Color, GRAPHICS_OPTIONS
+
+z=0
 
 class WL2MLP:
     def __init__(self, expr, evaluation):
@@ -52,7 +54,8 @@ class WL2MLP:
 
     def show(self, evaluation):
         self._complete_render(evaluation)
-        self.context["fig"].show()
+        #self.context["fig"].show()
+        plt.show()
 
     def export(self, filename, evaluation, format=None):
         self._complete_render(evaluation)
@@ -320,7 +323,16 @@ class MPLShow(Builtin):
     # This is copied Graphics in graphics.py
     # DRY the two
     options = GRAPHICS_OPTIONS
-    
+    rules = {
+        
+    }
+    def apply_box(self, content, evaluation):
+        """System`MakeBoxes[System`content_System`Graphics, System`StandardForm]"""
+#        """System`MakeBoxes[System`content_System`Graphics, System`StandardForm|System`TraditionalForm|System`OutputForm]"""
+        self.apply(content, evaluation, [])
+        return String("--Graphics--")
+
+
     def apply(self, expr, evaluation, options):
         "%(name)s[expr_, OptionsPattern[%(name)s]]"
         # Process the options
@@ -329,13 +341,10 @@ class MPLShow(Builtin):
         for opt in options:
             context["options"][opt] = options[opt]
 
-        context["style"]["ticks_style"] = options.get('System`TicksStyle').to_python()
-        context["style"]["axes_style"] = options.get('System`AxesStyle').to_python()
-        context["style"]["axes"] = options.get('System`Axes').to_python()
         wl2mpl.show(evaluation)
         return expr
 
-
+    
 if __name__ == "__main__":
     from mathics.session import MathicsSession
 


### PR DESCRIPTION
In this PR I start writing what I think this package should be. The package exposes two Symbols:
* ``MPLShow``
* ``MLPExportGraphics``
The first takes a Graphics / GraphicsBox expression, build an mpl graphics, and show it. Se second will be the basis for exporting graphics expressions to image files like png, svg or pdf. Which this, at least for 2d graphics, we will simplify a lot the current graphics module.
Internally, we have the class ``WL2MLP`` which is the true responsible of building the graphics.  

With the current implementation, you can do 
``MPLShow[Plot[f[x],{x,0,2}]]``
and get a (black and white) plot of the function f[x]. Also you can make graphics including rectangles, circles, disks, lines and text.